### PR TITLE
add stop network sampling & fix pid not in result of network stats

### DIFF
--- a/tidevice/_instruments.py
+++ b/tidevice/_instruments.py
@@ -914,6 +914,10 @@ class ServiceInstruments(DTXService):
         ch_network = 'com.apple.xcode.debug-gauge-data-providers.NetworkStatistics'
         return self.call_message(ch_network, 'startSamplingForPIDs:', [{pid}])
 
+    def stop_network_sampling(self, pid: int):
+        ch_network = 'com.apple.xcode.debug-gauge-data-providers.NetworkStatistics'
+        return self.call_message(ch_network, 'stopSamplingForPIDs:', [{pid}])
+
     def get_process_network_stats(self, pid: int) -> Iterator[dict]:
         """
         经测试数据始终不是很准，用safari测试，每次刷新图片的时候，rx.bytes总是不动
@@ -935,7 +939,7 @@ class ServiceInstruments(DTXService):
             'net.tx.packets.delta'
         }, {pid}]
         ret = self.call_message(ch_network, 'sampleAttributes:forPIDs:', args)
-        return ret[pid]
+        return ret[pid] if pid in ret else ret
     
     def iter_network(self) -> Iterator[dict]:
         """


### PR DESCRIPTION
1. add `stop_network_sampling`, which maybe mirror of `start_network_sampling`, it does work on iPhone X, and it is a good habit to release resource after using it
2. specific pid may not in result of `get_process_network_stats`, for there is no bytes exchanged by the process or somehow, returning statistics of other process, just let user decides how to do