### PR TITLE
Add env option for wdaproxy cmd

### DIFF
--- a/tidevice/__main__.py
+++ b/tidevice/__main__.py
@@ -323,8 +323,16 @@ def cmd_relay(args: argparse.Namespace):
 def cmd_wdaproxy(args: argparse.Namespace):
     """ start xctest and relay """
     d = _udid2device(args.udid)
+    
+    env = {}
+    for kv in args.env or {}:
+        key, val = kv.split(":", 1)
+        env[key] = val
+    if env:
+        logger.info("Launch env: %s", env)
+    
+    serv = WDAService(d, args.bundle_id, env)
 
-    serv = WDAService(d, args.bundle_id)
     p = None
     if args.port:
         cmds = [
@@ -615,7 +623,10 @@ _commands = [
              dict(args=['-p', '--port'],
                   type=int,
                   default=8100,
-                  help='pc listen port, set to 0 to disable port forward')
+                  help='pc listen port, set to 0 to disable port forward'),
+             dict(args=['-e', '--env'],
+                  action='append',
+                  help="set env with format key:value, support multi -e"),
          ],
          help='keep WDA running and relay WDA service to pc'),
     dict(action=cmd_syslog, command='syslog', help="print iphone syslog"),


### PR DESCRIPTION
Added support for -e env option to wdaproxy command just like the existing support for it on xctest command.

This is done to allow MJPEG_SERVER_PORT to be set for those who wish to.