### PR TITLE
fix README.md :新版本需要传入性能数据类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,10 +309,12 @@ How to get app performance in python
 ```python
 import time
 import tidevice
+from tidevice._perf import DataType
 
 t = tidevice.Device()
-perf = tidevice.Performance(t)
-
+perf = tidevice.Performance(t, [DataType.CPU, DataType.MEMORY, DataType.NETWORK, DataType.FPS, DataType.PAGE, DataType.SCREENSHOT])
+#  tidevice version <= 0.4.16:
+#  perf = tidevice.Performance(t)
 
 def callback(_type: tidevice.DataType, value: dict):
     print("R:", _type.value, value)


### PR DESCRIPTION
在0.4.17以及之后的版本中，Performance类需要传入性能数据类型，否则无法获取性能数据。我更新了READMD中的demo，改成传入所有参数。