### PR TITLE
Correctly handle man_in_middle_ssl proxy when com.apple.instruments.remoteserver unwrap ssl

### DIFF
--- a/scripts/run-usbmuxd-proxy.sh
+++ b/scripts/run-usbmuxd-proxy.sh
@@ -86,7 +86,7 @@ function recover() {
 	# https://github.com/alibaba/taobao-iphone-device/commit/bb0c56eb05bf10fbd48c3f9dd0f811d3e7192306
 	# 当plistdump-tcp-proxy.py异常结束时，socat会继续运行导致端口占用，所以这里必须kill掉
 	kill %%
-	mv ${BACKUP_SOCKET} ${SOCKET}
+	safe_run false mv ${BACKUP_SOCKET} ${SOCKET}
 }
 
 safe_run false mv ${SOCKET} ${BACKUP_SOCKET}


### PR DESCRIPTION
e.g.: when run `tidevice ps` through plistdump-tcp-proxy gets:
```
tidevice.exceptions.MuxError: connection closed
```
and 
```
[W 220413 02:37:06 plistdump-tcp-proxy:128] SSLError: tag: 8, [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2633)
```
