### PR TITLE
add energy supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ QQ交流群: _134535547_  (进群答案: ios)
 - 列出安装应用信息
 - 模拟Xcode运行XCTest，常用的如启动WebDriverAgent测试（此方法不依赖xcodebuild)
 - 获取指定应用性能(CPU,MEM,FPS)
+- 获取指定应用功耗(CPU,GPU,network,display,location)
 - 文件操作
 - Crash日志操作
 - 其他
@@ -331,6 +332,12 @@ screenshot {'value': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=231x50
 fps {'fps': 58, 'value': 58, 'timestamp': 1620725873152}
 cpu {'timestamp': 1620725873348, 'pid': 21243, 'value': 1.2141945711006428}
 memory {'pid': 21243, 'timestamp': 1620725873348, 'value': 40.54920196533203}
+```
+
+```bash
+# 功耗采集
+$ tidevice energy com.example.demo
+{"energy.overhead": 490.0, "kIDEGaugeSecondsSinceInitialQueryKey": 1209, "energy.version": 1, "energy.gpu.cost": 0, "energy.cpu.cost": 62.15080582703523, "energy.networkning.overhead": 500, "energy.appstate.cost": 8, "energy.location.overhead": 0, "energy.thermalstate.cost": 0, "energy.networking.cost": 501.341030606293, "energy.cost": 767.8212481980341, "energy.display.cost": 214.3294117647059, "energy.cpu.overhead": 0, "energy.location.cost": 0, "energy.gpu.overhead": 0, "energy.appstate.overhead": 0, "energy.display.overhead": 0, "energy.inducedthermalstate.cost": -1}
 ```
 
 How to get app performance in python

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,6 +14,7 @@ Command line tool to communicate with iOS device, support the following function
 - launch and kill app
 - list installed app info
 - retrieve performance data
+- retrieve energy data
 - simulate run xctest, eg: WebDriverAgent
 - file operation
 - crash log operation
@@ -302,6 +303,13 @@ screenshot {'value': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=231x50
 fps {'fps': 58, 'value': 58, 'timestamp': 1620725873152}
 cpu {'timestamp': 1620725873348, 'pid': 21243, 'value': 1.2141945711006428}
 memory {'pid': 21243, 'timestamp': 1620725873348, 'value': 40.54920196533203}
+```
+
+### Energy
+How to use in command line
+```bash
+$ tidevice energy com.example.demo
+{"energy.overhead": 490.0, "kIDEGaugeSecondsSinceInitialQueryKey": 1209, "energy.version": 1, "energy.gpu.cost": 0, "energy.cpu.cost": 62.15080582703523, "energy.networkning.overhead": 500, "energy.appstate.cost": 8, "energy.location.overhead": 0, "energy.thermalstate.cost": 0, "energy.networking.cost": 501.341030606293, "energy.cost": 767.8212481980341, "energy.display.cost": 214.3294117647059, "energy.cpu.overhead": 0, "energy.location.cost": 0, "energy.gpu.overhead": 0, "energy.appstate.overhead": 0, "energy.display.overhead": 0, "energy.inducedthermalstate.cost": -1}
 ```
 
 Example with python

--- a/tidevice/__main__.py
+++ b/tidevice/__main__.py
@@ -309,6 +309,20 @@ def cmd_applist(args: argparse.Namespace):
         #     (bundle_path, bundle_id, info['DisplayName'],
         #         info.get('Version', ''), info['Type'])))
 
+def cmd_energy(args: argparse.Namespace):
+    d = _udid2device(args.udid)
+    try:
+        pid = d.instruments.app_launch(args.bundle_id,
+                                       args=args.arguments,
+                                       kill_running=args.kill)
+        d.instruments.start_energy_sampling(pid)
+        while True:
+            ret = d.instruments.get_process_energy_stats(pid)
+            if ret != None:
+                print(json.dumps(ret))
+            time.sleep(1.0)
+    except ServiceError as e:
+        sys.exit(e)
 
 def cmd_launch(args: argparse.Namespace):
     d = _udid2device(args.udid)
@@ -688,6 +702,16 @@ _commands = [
          help='wait for device attached'),
     dict(action=cmd_launch,
          command="launch",
+         flags=[
+             dict(args=['--kill'],
+                  action='store_true',
+                  help='kill app if running'),
+             dict(args=["bundle_id"], help="app bundleId"),
+             dict(args=['arguments'], nargs='*', help='app arguments'),
+         ],
+         help="launch app with bundle_id"),
+    dict(action=cmd_energy,
+         command="energy",
          flags=[
              dict(args=['--kill'],
                   action='store_true',

--- a/tidevice/_instruments.py
+++ b/tidevice/_instruments.py
@@ -936,7 +936,20 @@ class ServiceInstruments(DTXService):
             # aux = AUXMessageBuffer()
             # aux.append_obj(channel_id)
             # self.send_dtx_message(channel_id, DTXPayload.build('_channelCanceled:', aux))
-            
+
+    def start_energy_sampling(self, pid: int):
+        ch_network = InstrumentsService.XcodeEnergyStatistics
+        return self.call_message(ch_network, 'startSamplingForPIDs:', [{pid}])
+
+    def stop_energy_sampling(self, pid: int):
+        ch_network = InstrumentsService.XcodeEnergyStatistics
+        return self.call_message(ch_network, 'stopSamplingForPIDs:', [{pid}])
+
+    def get_process_energy_stats(self, pid: int) -> Optional[Iterator[dict]]:
+        ch_network = InstrumentsService.XcodeEnergyStatistics
+        args = [{}, {pid}]
+        ret = self.call_message(ch_network, 'sampleAttributes:forPIDs:', args)
+        return ret.get(pid)
 
     def start_network_sampling(self, pid: int):
         ch_network = 'com.apple.xcode.debug-gauge-data-providers.NetworkStatistics'

--- a/tidevice/_proto.py
+++ b/tidevice/_proto.py
@@ -321,6 +321,7 @@ class InstrumentsService(str, enum.Enum):
     GraphicsOpengl = "com.apple.instruments.server.services.graphics.opengl"  # 获取FPS
     Sysmontap = "com.apple.instruments.server.services.sysmontap"  # 获取性能数据用
     XcodeNetworkStatistics = 'com.apple.xcode.debug-gauge-data-providers.NetworkStatistics'  # 获取单进程网络数据
+    XcodeEnergyStatistics = 'com.apple.xcode.debug-gauge-data-providers.Energy' # 获取功耗数据
     Networking = 'com.apple.instruments.server.services.networking'  # 全局网络数据 instruments 用的就是这个
     MobileNotifications = 'com.apple.instruments.server.services.mobilenotifications'  # 监控应用状态
 


### PR DESCRIPTION
Allows capture energy for specific app.

```bash
tidevice energy com.kiloo.subwaysurfers
```

```json
{"energy.overhead": -10.0, "kIDEGaugeSecondsSinceInitialQueryKey": 0, "energy.version": 1, "energy.networkning.overhead": 0, "energy.appstate.cost": 8, "energy.location.overhead": 0, "energy.thermalstate.cost": 0, "energy.networking.cost": 0, "energy.cost": -10.0, "energy.cpu.overhead": 0, "energy.appstate.overhead": 0, "energy.gpu.overhead": 0, "energy.inducedthermalstate.cost": -1, "energy.display.overhead": 0}
{"energy.overhead": -10.0, "kIDEGaugeSecondsSinceInitialQueryKey": 2, "energy.version": 1, "energy.gpu.cost": 0, "energy.cpu.cost": 0, "energy.networkning.overhead": 0, "energy.appstate.cost": 8, "energy.location.overhead": 0, "energy.thermalstate.cost": 0, "energy.networking.cost": 0, "energy.cost": -10.0, "energy.display.cost": 0, "energy.cpu.overhead": 0, "energy.location.cost": 0, "energy.gpu.overhead": 0, "energy.appstate.overhead": 0, "energy.display.overhead": 0, "energy.inducedthermalstate.cost": -1}
{"energy.overhead": -10.0, "kIDEGaugeSecondsSinceInitialQueryKey": 3, "energy.version": 1, "energy.gpu.cost": 0, "energy.cpu.cost": 204.37354880243336, "energy.networkning.overhead": 0, "energy.appstate.cost": 8, "energy.location.overhead": 0, "energy.thermalstate.cost": 0, "energy.networking.cost": 0, "energy.cost": 580.3500193906686, "energy.display.cost": 385.97647058823526, "energy.cpu.overhead": 0, "energy.location.cost": 0, "energy.gpu.overhead": 0, "energy.appstate.overhead": 0, "energy.display.overhead": 0, "energy.inducedthermalstate.cost": -1}
```