### PR TITLE
add env settings to launch command

### DIFF
--- a/tidevice/__main__.py
+++ b/tidevice/__main__.py
@@ -334,9 +334,18 @@ def cmd_energy(args: argparse.Namespace):
 
 def cmd_launch(args: argparse.Namespace):
     d = _udid2device(args.udid)
+
+    env = {}
+    for kv in args.env or []:
+        key, val = kv.split(":", 1)
+        env[key] = val
+    if env:
+        logger.info("App launch env: %s", env)
+
     try:
         with d.instruments_context() as ts:
             pid = ts.app_launch(args.bundle_id,
+                                        app_env=env,
                                         args=args.arguments,
                                         kill_running=args.kill)
             print("PID:", pid)
@@ -753,6 +762,10 @@ _commands = [
                   help='kill app if running'),
              dict(args=["bundle_id"], help="app bundleId"),
              dict(args=['arguments'], nargs='*', help='app arguments'),
+             dict(
+                 args=['-e', '--env'],
+                 action='append',
+                 help="set env with format key:value, support multi -e"),
          ],
          help="launch app with bundle_id"),
     dict(action=cmd_energy,

--- a/tidevice/_instruments.py
+++ b/tidevice/_instruments.py
@@ -653,6 +653,7 @@ class ServiceInstruments(DTXService):
 
     def app_launch(self,
                    bundle_id: str,
+                   app_env: dict = {},
                    args: list = [],
                    kill_running: bool = False) -> int:
         """
@@ -662,8 +663,6 @@ class ServiceInstruments(DTXService):
         code = self.make_channel(self._SERVICE_PROCESS_CONTROL)
         method = "launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:"
         app_path = ""  # not used, just pass empty string
-        app_env = {
-        }  # environment variables: not used, just pass empty dictionary
         #app_args = []  # not used, just pass empty array
 
         options = {


### PR DESCRIPTION
给应用启动添加环境变量支持。
比如WDA的默认端口可以通过环境变量设置：
详见 [bindingPortRange](https://github.com/appium/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/FBConfiguration.m) 方法
这样可以通过
`tidevice launch com.facebook.wda.WebDriverAgent.Runner -e USE_PORT:8101 -e MJPEG_SERVER_PORT:9101` 
去自定义端口

在模拟器场景下比较使用，多模拟器共用宿主机端口，可单独指定每台模拟器上WDA绑定的端口号，更方便外部调用。
