### PR TITLE
Update _perf.py

### DIFF
--- a/tidevice/_perf.py
+++ b/tidevice/_perf.py
@@ -124,13 +124,16 @@ def iter_screenshot(d: BaseDevice) -> Iterator[Tuple[DataType, dict]]:
         _time = time.time()
         img.thumbnail((500, 500))  # 缩小图片已方便保存
         
+        buffered = BytesIO()
+        img.save(buffered, format="JPEG")
+        img_str = base64.b64encode(buffered.getvalue())
+        
         # example of convert image to bytes
         # buf = io.BytesIO()
         # img.save(buf, format="JPEG")
 
         # turn image to URL
-        yield DataType.SCREENSHOT, {"time": _time, "value": img}
-
+        yield DataType.SCREENSHOT, {"time": _time, "value": img, "img_str": img_str, "screenshot": "screenshot"}
 
 
 ProcAttrs = namedtuple("ProcAttrs", SYSMON_PROC_ATTRS)
@@ -315,7 +318,7 @@ class Performance():
         if DataType.GPU in self._perfs:
             iters.append(iter_gpu(self._d))
         if DataType.SCREENSHOT in self._perfs:
-            iters.append(set_interval(iter_screenshot(self._d), 1.0))
+            iters.append(set_interval(iter_screenshot(self._d), 2.0))
         if DataType.NETWORK in self._perfs:
             iters.append(iter_network_flow(self._d, self._rp))
         for it in (iters): # yapf: disable

--- a/tidevice/_perf.py
+++ b/tidevice/_perf.py
@@ -133,7 +133,7 @@ def iter_screenshot(d: BaseDevice) -> Iterator[Tuple[DataType, dict]]:
         # img.save(buf, format="JPEG")
 
         # turn image to URL
-        yield DataType.SCREENSHOT, {"time": _time, "value": img, "img_str": img_str, "screenshot": "screenshot"}
+        yield DataType.SCREENSHOT, {"time": _time, "value": img, "img_str": img_str, "type": "screenshot"}
 
 
 ProcAttrs = namedtuple("ProcAttrs", SYSMON_PROC_ATTRS)

--- a/tidevice/_perf.py
+++ b/tidevice/_perf.py
@@ -122,7 +122,7 @@ def iter_gpu(d: BaseDevice) -> Iterator[Any]:
 def iter_screenshot(d: BaseDevice) -> Iterator[Tuple[DataType, dict]]:
     for img in d.iter_screenshot():
         _time = time.time()
-        img.thumbnail((500, 500))  # 缩小图片已方便保存
+        img.thumbnail((200, 200))  # 缩小图片已方便保存
         
         buffered = BytesIO()
         img.save(buffered, format="JPEG")


### PR DESCRIPTION
Hi ,

I'm using this library for my mac os x application. I can getting the screenshot value like "screenshot {'value': <PIL.PngImagePlugin.PngImageFile image mode=RGB size=349x500 at 0x10F663290>, 'timestamp': 1682069034630}" using "tidevice perf -B com.example.app" command. In frontend we are using swift language and we can't convert screenshot value "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=349x500 at 0x10F663290>" to NSImage. So I modified your code(in my local) like converting image to bytes(as modified in the below code) and send to front end. In front end(swift) we can convert the bytes to image and it's working fine. The problem is when I install the tidevice using "pip3 install -U tidevice" command the modified code was removed and new file installed from github. So I can't using the modified code. The code I need to update in github below are


def iter_screenshot(d: BaseDevice) -> Iterator[Tuple[DataType, dict]]:
    for img in d.iter_screenshot():
        _time = time.time()
        img.thumbnail((200, 200))  # 缩小图片已方便保存
        
        buffered = BytesIO()
        img.save(buffered, format="JPEG")
        img_str = base64.b64encode(buffered.getvalue())
        
        # example of convert image to bytes
        # buf = io.BytesIO()
        # img.save(buf, format="JPEG")

        # turn image to URL
        yield DataType.SCREENSHOT, {"time": _time, "value": img, "img_str": img_str, "type": "screenshot"}

Kindly do the needfull.  Thanks.