### PR TITLE
Enable iOS16 developer mode only for iOS 16

### DIFF
--- a/tidevice/_device.py
+++ b/tidevice/_device.py
@@ -664,7 +664,7 @@ class BaseDevice():
         Raises:
             MuxError, ServiceError
         """
-        if semver_compare(self.product_version, "15.7.2") >= 0:
+        if semver_compare(self.product_version, "16.0.0") >= 0:
             self.enable_ios16_developer_mode()
         try:
             if self.imagemounter.is_developer_mounted():


### PR DESCRIPTION
Apple released iOS 15.7.5 and tidevice stopped working for the devices with this version due to the invalid version check. An issue similar to #294 

Comparing the version to iOS 16 directly should address it for good.