### PR TITLE
fix: linux中长时间反复启动获取性能数据sokcet累增没有释放导致一段时间后ConnectionRefused无法再获取的现象

### DIFF
--- a/tidevice/_safe_socket.py
+++ b/tidevice/_safe_socket.py
@@ -79,7 +79,9 @@ class SafeStreamSocket:
     def _cleanup(self):
         release_uid(self.id)
         if self._dup_sock:
+            self._dup_sock.shutdown(socket.SHUT_RDWR)
             self._dup_sock.close()
+        self._sock.shutdown(socket.SHUT_RDWR)
         self._sock.close()
 
     def close(self):


### PR DESCRIPTION
问题描述：
1. linux环境，用_perf获取性能数据(tidevice-0.10.7)，脚本分时段多次反复start,stop去不断获取，用一段时间后就报错ConnectionRefused获取不到了，大概反复几十次一两个小时就会高概率出现，更换数据线、linux和手机都会有出现
2. 分析发现在反复启动获取perf时，linux上netstat | grep usbmux，数据会不断地新增且不会减少，感觉是没有释放socket最后塞满了
3. 查询资料，在Linux上，关闭socket并不意味着立即释放所有相关的资源。虽然关闭socket会导致该socket的文件描述符变为不可用状态，但底层的网络资源可能不会立即释放。如果你希望立即释放socket资源，可以使用以下方法之一：1. 调用`shutdown()`方法：在关闭socket前，先调用`socket.shutdown(socket.SHUT_RDWR)`方法来关闭socket的读写能力

fix验证：
1. 先shutdown再close，实测相同场景下2台手机反复获取2小时，获取次数200次+，没有再出现之前的问题