### PR TITLE
Check XCTest result and raise error if it failed

### DIFF
--- a/tidevice/_device.py
+++ b/tidevice/_device.py
@@ -40,7 +40,7 @@ from ._ipautil import IPAReader
 from ._proto import *
 from ._safe_socket import *
 from ._sync import Sync
-from ._types import DeviceInfo
+from ._types import DeviceInfo, XCTestResult
 from ._usbmux import Usbmux
 from ._utils import (ProgressReader, get_app_dir, semver_compare,
                      set_socket_timeout)
@@ -1072,10 +1072,30 @@ class BaseDevice():
                 logger.info("Test runner ready detected")
                 _start_executing()
 
+        test_results = []
+        test_results_lock = threading.Lock()
+
+        def _record_test_result_callback(m: DTXMessage):
+            result = None
+            if isinstance(m.result, (tuple, list)) and len(m.result) >= 1:
+              if isinstance(m.result[1], (tuple, list)):
+                  try:
+                    result = XCTestResult(*m.result[1])
+                  except TypeError:
+                    pass
+            if not result:
+                logger.warning('Ignore unknown test result message: %s', m)
+                return
+            with test_results_lock:
+                test_results.append(result)
+
         x2.register_callback(
             '_XCT_testBundleReadyWithProtocolVersion:minimumVersion:',
             _start_executing)  # This only happends <= iOS 13
         x2.register_callback('_XCT_logDebugMessage:', _show_log_message)
+        x2.register_callback(
+            "_XCT_testSuite:didFinishAt:runCount:withFailures:unexpected:testDuration:totalDuration:",
+            _record_test_result_callback)
 
         # index: 469
         identifier = '_IDE_initiateSessionWithIdentifier:forClient:atPath:protocolVersion:'
@@ -1144,7 +1164,15 @@ class BaseDevice():
         # on windows threading.Event.wait can't handle ctrl-c
         while not quit_event.wait(.1):
             pass
-        logger.info("xctrunner quited")
+
+        test_result_str = "\n".join(map(str, test_results))
+        if any(result.failure_count > 0 for result in test_results):
+              raise RuntimeError(
+                  "Xcode test failed on device with test results:\n"
+                  f"{test_result_str}"
+              )
+
+        logger.info("xctrunner quited with result:\n%s", test_result_str)
 
 
 Device = BaseDevice

--- a/tidevice/_types.py
+++ b/tidevice/_types.py
@@ -49,3 +49,40 @@ class DeviceInfo(_BaseInfo):
     udid: str = alias_field("SerialNumber")
     device_id: int = alias_field("DeviceID")
     conn_type: ConnectionType = alias_field("ConnectionType")
+
+
+@dataclass(frozen=True)
+class XCTestResult(_BaseInfo):
+    """Representing the XCTest result printed at the end of test.
+
+    At the end of an XCTest, the test process will print following information:
+
+      Test Suite 'MoblySignInTests' passed at 2023-09-03 16:35:39.214.
+              Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.864) seconds
+      Test Suite 'MoblySignInTests.xctest' passed at 2023-09-03 16:35:39.216.
+               Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.866) seconds
+      Test Suite 'Selected tests' passed at 2023-09-03 16:35:39.217.
+               Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.869) seconds
+    """
+
+    MESSAGE = (
+        "Test Suite '{test_suite_name}' passed at {end_time}.\n"
+        "\t Executed {run_count} test, with {failure_count} failures ({unexpected_count} unexpected) in {test_duration:.3f} ({total_duration:.3f}) seconds"
+    )
+
+    test_suite_name: str = alias_field('TestSuiteName')
+    end_time: str = alias_field('EndTime')
+    run_count: int = alias_field('RunCount')
+    failure_count: int = alias_field('FailureCount')
+    unexpected_count: int = alias_field('UnexpectedCount')
+    test_duration: float = alias_field('TestDuration')
+    total_duration: float = alias_field('TotalDuration')
+
+    def __repr__(self) -> str:
+      return self.MESSAGE.format(
+          test_suite_name=self.test_suite_name, end_time=self.end_time,
+          run_count=self.run_count, failure_count=self.failure_count,
+          unexpected_count=self.unexpected_count,
+          test_duration=self.test_duration,
+          total_duration=self.total_duration,
+      )

--- a/tidevice/_types.py
+++ b/tidevice/_types.py
@@ -57,12 +57,12 @@ class XCTestResult(_BaseInfo):
 
     At the end of an XCTest, the test process will print following information:
 
-      Test Suite 'MoblySignInTests' passed at 2023-09-03 16:35:39.214.
-              Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.864) seconds
-      Test Suite 'MoblySignInTests.xctest' passed at 2023-09-03 16:35:39.216.
-               Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.866) seconds
-      Test Suite 'Selected tests' passed at 2023-09-03 16:35:39.217.
-               Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.869) seconds
+        Test Suite 'MoblySignInTests' passed at 2023-09-03 16:35:39.214.
+                Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.864) seconds
+        Test Suite 'MoblySignInTests.xctest' passed at 2023-09-03 16:35:39.216.
+                 Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.866) seconds
+        Test Suite 'Selected tests' passed at 2023-09-03 16:35:39.217.
+                 Executed 1 test, with 0 failures (0 unexpected) in 3.850 (3.869) seconds
     """
 
     MESSAGE = (
@@ -79,10 +79,10 @@ class XCTestResult(_BaseInfo):
     total_duration: float = alias_field('TotalDuration')
 
     def __repr__(self) -> str:
-      return self.MESSAGE.format(
-          test_suite_name=self.test_suite_name, end_time=self.end_time,
-          run_count=self.run_count, failure_count=self.failure_count,
-          unexpected_count=self.unexpected_count,
-          test_duration=self.test_duration,
-          total_duration=self.total_duration,
-      )
+        return self.MESSAGE.format(
+            test_suite_name=self.test_suite_name, end_time=self.end_time,
+            run_count=self.run_count, failure_count=self.failure_count,
+            unexpected_count=self.unexpected_count,
+            test_duration=self.test_duration,
+            total_duration=self.total_duration,
+        )


### PR DESCRIPTION
Currently, `tidevice xctest` will return normally if the XCTest failed on the device.

This PR adds the logic to check the XCTest result and raise an error if it failed. E.g. Following is the log when the XCTest failed:

```
[D 230905 16:44:41 _instruments:423] SEND DTXMessage: channel:1 expect_reply:0 data_length:48, data...
[D 230905 16:44:41 _instruments:641] RECV DTXMessage: expects_reply:0 flags:2 conv:0 ('pidDiedCallback:', [16518])
[D 230905 16:44:41 _instruments:622] dtxm socket closed
[D 230905 16:44:41 _instruments:654] Ignore notification from server: 66, 0x2, ('pidDiedCallback:', [16518])
Traceback (most recent call last):
  File "/usr/local/google/home/minghaoli/npy3/bin/tidevice", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/google/home/minghaoli/npy3/lib/python3.11/site-packages/tidevice/__main__.py", line 1004, in main
    actions[args.subparser](args)
  File "/usr/local/google/home/minghaoli/npy3/lib/python3.11/site-packages/tidevice/__main__.py", line 279, in cmd_xctest
    d.xctest(args.bundle_id,
  File "/usr/local/google/home/minghaoli/npy3/lib/python3.11/site-packages/tidevice/_device.py", line 996, in xctest
    return self.xcuitest(bundle_id, target_bundle_id=target_bundle_id,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/google/home/minghaoli/npy3/lib/python3.11/site-packages/tidevice/_device.py", line 1172, in xcuitest
    raise RuntimeError(
RuntimeError: Xcode test failed on device with test results:
Test Suite 'MHSignInTests' passed at 2023-09-05 08:44:41 +0000.
	 Executed 2 test, with 2 failures (0 unexpected) in 6.069 (6.086) seconds
Test Suite 'SystemProxyTests.xctest' passed at 2023-09-05 08:44:41 +0000.
	 Executed 2 test, with 2 failures (0 unexpected) in 6.069 (6.089) seconds
Test Suite 'All tests' passed at 2023-09-05 08:44:41 +0000.
	 Executed 2 test, with 2 failures (0 unexpected) in 6.069 (6.093) seconds
2023-09-05 16:44:41.822 | INFO     | tidevice._safe_socket:release_uid:44 - Closing socket, id=20
2023-09-05 16:44:41.823 | INFO     | tidevice._safe_socket:release_uid:44 - Closing socket, id=13
[D 230905 16:44:41 _instruments:622] dtxm socket closed
2023-09-05 16:44:41.823 | INFO     | tidevice._safe_socket:release_uid:44 - Closing socket, id=9
[W 230905 16:44:41 _device:948] WebDriverAgentRunner quitted
[D 230905 16:44:41 _instruments:622] dtxm socket closed
```
