### PR TITLE
fix: Requests>=2.32.2 get_connection DEPRECATED

### DIFF
--- a/tidevice/requests_usbmux.py
+++ b/tidevice/requests_usbmux.py
@@ -73,6 +73,9 @@ class UsbmuxAdapter(HTTPAdapter):
         self.pools = urllib3._collections.RecentlyUsedContainer(
             pool_connections, dispose_func=lambda p: p.close())
 
+    def get_connection_with_tls_context(self, request, verify=False, proxies=None, cert=None):
+        return self.get_connection(request.url, proxies)
+
     def get_connection(self, url, proxies=None):
         proxies = proxies or {}
         proxy = proxies.get(urlparse(url.lower()).scheme)

--- a/tidevice/requests_usbmux.py
+++ b/tidevice/requests_usbmux.py
@@ -74,7 +74,7 @@ class UsbmuxAdapter(HTTPAdapter):
             pool_connections, dispose_func=lambda p: p.close())
 
     def get_connection_with_tls_context(self, request, verify=False, proxies=None, cert=None):
-        return self.get_connection(request.url, proxies)
+        return self.get_connection(request.url, proxies), None
 
     def get_connection(self, url, proxies=None):
         proxies = proxies or {}


### PR DESCRIPTION
在最新的requests 版本中，移除了 get_connection 方法，导致tidevice 启动 wdaproxy 时调用到 get_connection_with_tls_context 方法导致报错 "request error: Not supported URL scheme http+usbmux"

request 相关改动issue: https://github.com/psf/requests/pull/6710

requests 包中详细说明如下 ：

```python
    def get_connection(self, url, proxies=None):
        """DEPRECATED: Users should move to `get_connection_with_tls_context`
        for all subclasses of HTTPAdapter using Requests>=2.32.2.

        Returns a urllib3 connection for the given URL. This should not be
        called from user code, and is only exposed for use when subclassing the
        :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.

        :param url: The URL to connect to.
        :param proxies: (optional) A Requests-style dictionary of proxies used on this request.
        :rtype: urllib3.ConnectionPool
        """
        warnings.warn(
            (
                "`get_connection` has been deprecated in favor of "
                "`get_connection_with_tls_context`. Custom HTTPAdapter subclasses "
                "will need to migrate for Requests>=2.32.2. Please see "
                "https://github.com/psf/requests/pull/6710 for more details."
            ),
            DeprecationWarning,
        )
```